### PR TITLE
feat: Embedded Summary Cards for GitHub PR Checks (#28)

### DIFF
--- a/src/summary-card.test.ts
+++ b/src/summary-card.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeVerdict,
+  buildCardData,
+  renderCompactMarkdown,
+  renderDetailedMarkdown,
+  renderJson,
+  renderHtml,
+  renderGitHubAnnotations,
+  renderCard,
+  generateSummaryCard,
+  generateAnnotations,
+  type SummaryCardInput,
+} from './summary-card.js';
+
+function makeInput(overrides: Partial<SummaryCardInput> = {}): SummaryCardInput {
+  return {
+    synthesis: {
+      content:
+        'The code looks solid overall. Security practices are well-implemented. Minor style issues found.',
+      synthesizer: 'claude',
+      consensusScore: 0.85,
+      confidenceScore: 0.9,
+      controversial: false,
+      minorityReport: 'Ollama disagreed on the naming conventions.',
+      contributions: {
+        claude: ['security analysis'],
+        openai: ['style review'],
+      },
+    },
+    votes: {
+      rankings: [
+        { provider: 'claude', score: 8 },
+        { provider: 'openai', score: 6 },
+        { provider: 'ollama', score: 4 },
+      ],
+      winner: 'claude',
+      controversial: false,
+      details: {},
+    },
+    duration: 12500,
+    sessionId: 'test-session-123',
+    providers: ['claude', 'openai', 'ollama'],
+    confidenceThreshold: 0.7,
+    sessionUrl: 'https://example.com/session/123',
+    ...overrides,
+  };
+}
+
+describe('computeVerdict', () => {
+  it('returns pass for high confidence and consensus', () => {
+    expect(computeVerdict(0.9, 0.8, 0.7)).toBe('pass');
+  });
+
+  it('returns fail when confidence below threshold', () => {
+    expect(computeVerdict(0.3, 0.9, 0.7)).toBe('fail');
+  });
+
+  it('returns warn for low consensus', () => {
+    expect(computeVerdict(0.8, 0.4, 0.5)).toBe('warn');
+  });
+
+  it('returns warn for borderline confidence', () => {
+    expect(computeVerdict(0.55, 0.8, 0.5)).toBe('warn');
+  });
+
+  it('returns pass with zero threshold', () => {
+    expect(computeVerdict(0.1, 0.8, 0)).toBe('warn');
+  });
+});
+
+describe('buildCardData', () => {
+  it('builds card data from input', () => {
+    const data = buildCardData(makeInput());
+    expect(data.verdict).toBe('pass');
+    expect(data.verdictEmoji).toBe('✅');
+    expect(data.confidence).toBe(0.9);
+    expect(data.consensus).toBe(0.85);
+    expect(data.topFinding).toBeTruthy();
+    expect(data.dissent).toBe('Ollama disagreed on the naming conventions.');
+    expect(data.providerBreakdown).toHaveLength(3);
+    expect(data.providerBreakdown[0]!.isWinner).toBe(true);
+    expect(data.sessionUrl).toBe('https://example.com/session/123');
+  });
+
+  it('handles no dissent', () => {
+    const data = buildCardData(
+      makeInput({
+        synthesis: {
+          ...makeInput().synthesis,
+          minorityReport: undefined,
+        },
+      }),
+    );
+    expect(data.dissent).toBeNull();
+  });
+
+  it('handles "None" minority report', () => {
+    const data = buildCardData(
+      makeInput({
+        synthesis: {
+          ...makeInput().synthesis,
+          minorityReport: 'None',
+        },
+      }),
+    );
+    expect(data.dissent).toBeNull();
+  });
+
+  it('uses default session URL when not provided', () => {
+    const data = buildCardData(
+      makeInput({
+        sessionUrl: undefined,
+      }),
+    );
+    expect(data.sessionUrl).toContain('test-session-123');
+  });
+});
+
+describe('renderCompactMarkdown', () => {
+  it('stays within 500 char budget', () => {
+    const data = buildCardData(makeInput());
+    const card = renderCompactMarkdown(data);
+    expect(card.length).toBeLessThanOrEqual(500);
+  });
+
+  it('includes verdict, confidence, consensus', () => {
+    const data = buildCardData(makeInput());
+    const card = renderCompactMarkdown(data);
+    expect(card).toContain('PASS');
+    expect(card).toContain('90%');
+    expect(card).toContain('85%');
+  });
+
+  it('includes dissent when present', () => {
+    const data = buildCardData(makeInput());
+    const card = renderCompactMarkdown(data);
+    expect(card).toContain('Dissent');
+  });
+
+  it('includes provider names', () => {
+    const data = buildCardData(makeInput());
+    const card = renderCompactMarkdown(data);
+    expect(card).toContain('claude');
+    expect(card).toContain('👑');
+  });
+
+  it('enforces budget with very long content', () => {
+    const longContent = 'A'.repeat(300) + '. ' + 'B'.repeat(300) + '.';
+    const data = buildCardData(
+      makeInput({
+        synthesis: {
+          ...makeInput().synthesis,
+          content: longContent,
+          minorityReport: 'C'.repeat(200),
+        },
+      }),
+    );
+    const card = renderCompactMarkdown(data);
+    expect(card.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe('renderDetailedMarkdown', () => {
+  it('includes all sections', () => {
+    const data = buildCardData(makeInput());
+    const card = renderDetailedMarkdown(data);
+    expect(card).toContain('## ');
+    expect(card).toContain('Top Finding');
+    expect(card).toContain('Dissent');
+    expect(card).toContain('Provider Breakdown');
+    expect(card).toContain('claude');
+    expect(card).toContain('👑 Winner');
+  });
+
+  it('omits dissent section when none', () => {
+    const data = buildCardData(
+      makeInput({
+        synthesis: { ...makeInput().synthesis, minorityReport: undefined },
+      }),
+    );
+    const card = renderDetailedMarkdown(data);
+    expect(card).not.toContain('Dissent');
+  });
+});
+
+describe('renderJson', () => {
+  it('produces valid JSON', () => {
+    const data = buildCardData(makeInput());
+    const json = renderJson(data);
+    const parsed = JSON.parse(json);
+    expect(parsed.verdict).toBe('pass');
+    expect(parsed.confidence).toBe(0.9);
+    expect(parsed.providerBreakdown).toHaveLength(3);
+  });
+});
+
+describe('renderHtml', () => {
+  it('produces HTML with card structure', () => {
+    const data = buildCardData(makeInput());
+    const html = renderHtml(data);
+    expect(html).toContain('<div class="quorum-card">');
+    expect(html).toContain('PASS');
+    expect(html).toContain('<table>');
+    expect(html).toContain('</div>');
+  });
+
+  it('includes dissent when present', () => {
+    const data = buildCardData(makeInput());
+    const html = renderHtml(data);
+    expect(html).toContain('Dissent');
+  });
+
+  it('omits dissent when absent', () => {
+    const data = buildCardData(
+      makeInput({
+        synthesis: { ...makeInput().synthesis, minorityReport: undefined },
+      }),
+    );
+    const html = renderHtml(data);
+    expect(html).not.toContain('Dissent');
+  });
+});
+
+describe('renderGitHubAnnotations', () => {
+  it('emits ::notice for pass', () => {
+    const data = buildCardData(makeInput());
+    const annotations = renderGitHubAnnotations(data);
+    expect(annotations).toContain('::notice');
+    expect(annotations).toContain('Passed');
+  });
+
+  it('emits ::error for fail', () => {
+    const data = buildCardData(
+      makeInput({
+        synthesis: { ...makeInput().synthesis, confidenceScore: 0.3 },
+        confidenceThreshold: 0.7,
+      }),
+    );
+    const annotations = renderGitHubAnnotations(data);
+    expect(annotations).toContain('::error');
+    expect(annotations).toContain('Failed');
+  });
+
+  it('emits ::warning for warn', () => {
+    const data = buildCardData(
+      makeInput({
+        synthesis: { ...makeInput().synthesis, consensusScore: 0.3 },
+      }),
+    );
+    const annotations = renderGitHubAnnotations(data);
+    expect(annotations).toContain('::warning');
+    expect(annotations).toContain('Warning');
+  });
+
+  it('adds dissent annotation', () => {
+    const data = buildCardData(makeInput());
+    const annotations = renderGitHubAnnotations(data);
+    expect(annotations).toContain('Dissent');
+  });
+});
+
+describe('renderCard', () => {
+  it('dispatches to correct format', () => {
+    const data = buildCardData(makeInput());
+    expect(renderCard(data, 'json')).toContain('"verdict"');
+    expect(renderCard(data, 'html')).toContain('<div');
+    expect(renderCard(data, 'markdown')).toContain('**Quorum');
+    expect(renderCard(data, 'markdown', true)).toContain('## ');
+  });
+});
+
+describe('generateSummaryCard', () => {
+  it('generates compact markdown by default', () => {
+    const card = generateSummaryCard(makeInput());
+    expect(card.length).toBeLessThanOrEqual(500);
+    expect(card).toContain('PASS');
+  });
+
+  it('generates detailed markdown', () => {
+    const card = generateSummaryCard(makeInput(), 'markdown', true);
+    expect(card).toContain('Provider Breakdown');
+  });
+
+  it('generates JSON', () => {
+    const card = generateSummaryCard(makeInput(), 'json');
+    expect(JSON.parse(card).verdict).toBe('pass');
+  });
+});
+
+describe('generateAnnotations', () => {
+  it('generates GitHub Actions annotations', () => {
+    const annotations = generateAnnotations(makeInput());
+    expect(annotations).toContain('::notice');
+  });
+});

--- a/src/summary-card.ts
+++ b/src/summary-card.ts
@@ -1,0 +1,258 @@
+/**
+ * Summary Card generation for GitHub PR checks, Slack, and other surfaces.
+ * Produces compact (≤500 char) and detailed cards from deliberation results.
+ */
+
+import type { Synthesis } from './types.js';
+import type { VoteResult } from './council-v2.js';
+
+// --- Types ---
+
+export type CardVerdict = 'pass' | 'warn' | 'fail';
+export type CardFormat = 'markdown' | 'json' | 'html';
+
+export interface SummaryCardInput {
+  synthesis: Synthesis;
+  votes: VoteResult;
+  duration: number;
+  sessionId: string;
+  providers: string[];
+  /** Confidence threshold below which verdict is 'fail' */
+  confidenceThreshold?: number;
+  /** Drill-down link to full session (placeholder OK) */
+  sessionUrl?: string;
+}
+
+export interface SummaryCardData {
+  verdict: CardVerdict;
+  verdictEmoji: string;
+  confidence: number;
+  consensus: number;
+  topFinding: string;
+  dissent: string | null;
+  providerBreakdown: ProviderBreakdownEntry[];
+  duration: number;
+  sessionId: string;
+  sessionUrl: string;
+}
+
+export interface ProviderBreakdownEntry {
+  provider: string;
+  score: number;
+  isWinner: boolean;
+}
+
+// --- Verdict logic ---
+
+const VERDICT_EMOJI: Record<CardVerdict, string> = {
+  pass: '✅',
+  warn: '⚠️',
+  fail: '❌',
+};
+
+export function computeVerdict(
+  confidence: number,
+  consensus: number,
+  threshold: number,
+): CardVerdict {
+  if (confidence < threshold) return 'fail';
+  if (consensus < 0.5 || confidence < 0.6) return 'warn';
+  return 'pass';
+}
+
+// --- Extract top finding ---
+
+function extractTopFinding(content: string): string {
+  // Strip markdown headings, take first meaningful sentence
+  const cleaned = content
+    .replace(/^#{1,3}\s.*$/gm, '')
+    .replace(/\n{2,}/g, '\n')
+    .trim();
+  const sentences = cleaned.split(/(?<=[.!?])\s+/).filter((s) => s.trim().length > 10);
+  const first = sentences[0] ?? cleaned.slice(0, 150);
+  return first.length > 150 ? first.slice(0, 147) + '...' : first;
+}
+
+// --- Build card data ---
+
+export function buildCardData(input: SummaryCardInput): SummaryCardData {
+  const threshold = input.confidenceThreshold ?? 0;
+  const verdict = computeVerdict(
+    input.synthesis.confidenceScore,
+    input.synthesis.consensusScore,
+    threshold,
+  );
+
+  const providerBreakdown: ProviderBreakdownEntry[] = input.votes.rankings.map((r) => ({
+    provider: r.provider,
+    score: r.score,
+    isWinner: r.provider === input.votes.winner,
+  }));
+
+  const dissent =
+    input.synthesis.minorityReport &&
+    input.synthesis.minorityReport !== 'None' &&
+    input.synthesis.minorityReport.trim()
+      ? input.synthesis.minorityReport.trim()
+      : null;
+
+  return {
+    verdict,
+    verdictEmoji: VERDICT_EMOJI[verdict],
+    confidence: input.synthesis.confidenceScore,
+    consensus: input.synthesis.consensusScore,
+    topFinding: extractTopFinding(input.synthesis.content),
+    dissent,
+    providerBreakdown,
+    duration: input.duration,
+    sessionId: input.sessionId,
+    sessionUrl: input.sessionUrl ?? `#session-${input.sessionId}`,
+  };
+}
+
+// --- Compact card (≤500 chars) ---
+
+export function renderCompactMarkdown(data: SummaryCardData): string {
+  const lines: string[] = [];
+  lines.push(`${data.verdictEmoji} **Quorum: ${data.verdict.toUpperCase()}**`);
+  lines.push(
+    `Confidence: ${(data.confidence * 100).toFixed(0)}% | Consensus: ${(data.consensus * 100).toFixed(0)}%`,
+  );
+  lines.push('');
+  lines.push(`> ${data.topFinding}`);
+  if (data.dissent) {
+    const shortDissent =
+      data.dissent.length > 80 ? data.dissent.slice(0, 77) + '...' : data.dissent;
+    lines.push(`\n⚖️ Dissent: ${shortDissent}`);
+  }
+  const providers = data.providerBreakdown
+    .map((p) => `${p.provider}${p.isWinner ? '👑' : ''}`)
+    .join(', ');
+  lines.push(`\nProviders: ${providers}`);
+  lines.push(`[Full details](${data.sessionUrl})`);
+
+  let result = lines.join('\n');
+  // Enforce 500 char budget
+  if (result.length > 500) {
+    result = result.slice(0, 497) + '...';
+  }
+  return result;
+}
+
+// --- Detailed card (no limit) ---
+
+export function renderDetailedMarkdown(data: SummaryCardData): string {
+  const lines: string[] = [];
+  lines.push(`## ${data.verdictEmoji} Quorum Verdict: ${data.verdict.toUpperCase()}\n`);
+  lines.push(`| Metric | Value |`);
+  lines.push(`|--------|-------|`);
+  lines.push(`| Confidence | ${(data.confidence * 100).toFixed(1)}% |`);
+  lines.push(`| Consensus | ${(data.consensus * 100).toFixed(1)}% |`);
+  lines.push(`| Duration | ${(data.duration / 1000).toFixed(1)}s |`);
+  lines.push(`| Session | \`${data.sessionId}\` |`);
+  lines.push('');
+  lines.push(`### Top Finding\n`);
+  lines.push(`> ${data.topFinding}\n`);
+
+  if (data.dissent) {
+    lines.push(`### ⚖️ Dissent\n`);
+    lines.push(`${data.dissent}\n`);
+  }
+
+  lines.push(`### Provider Breakdown\n`);
+  lines.push(`| Provider | Score | Role |`);
+  lines.push(`|----------|-------|------|`);
+  for (const p of data.providerBreakdown) {
+    lines.push(`| ${p.provider} | ${p.score} | ${p.isWinner ? '👑 Winner' : ''} |`);
+  }
+  lines.push('');
+  lines.push(`[🔍 Full session details](${data.sessionUrl})`);
+
+  return lines.join('\n');
+}
+
+// --- JSON format ---
+
+export function renderJson(data: SummaryCardData): string {
+  return JSON.stringify(data, null, 2);
+}
+
+// --- HTML format ---
+
+export function renderHtml(data: SummaryCardData): string {
+  const providerRows = data.providerBreakdown
+    .map(
+      (p) =>
+        `<tr><td>${p.provider}</td><td>${p.score}</td><td>${p.isWinner ? '👑 Winner' : ''}</td></tr>`,
+    )
+    .join('\n      ');
+
+  return `<div class="quorum-card">
+  <h3>${data.verdictEmoji} Quorum: ${data.verdict.toUpperCase()}</h3>
+  <p>Confidence: ${(data.confidence * 100).toFixed(0)}% | Consensus: ${(data.consensus * 100).toFixed(0)}%</p>
+  <blockquote>${data.topFinding}</blockquote>
+  ${data.dissent ? `<p><strong>⚖️ Dissent:</strong> ${data.dissent}</p>` : ''}
+  <table>
+    <tr><th>Provider</th><th>Score</th><th>Role</th></tr>
+    ${providerRows}
+  </table>
+  <a href="${data.sessionUrl}">Full details</a>
+</div>`;
+}
+
+// --- GitHub Actions annotations ---
+
+export function renderGitHubAnnotations(data: SummaryCardData): string {
+  const lines: string[] = [];
+  const summary = `Quorum ${data.verdict.toUpperCase()}: Confidence ${(data.confidence * 100).toFixed(0)}%, Consensus ${(data.consensus * 100).toFixed(0)}%`;
+
+  if (data.verdict === 'fail') {
+    lines.push(`::error title=Quorum Review Failed::${summary}. ${data.topFinding}`);
+  } else if (data.verdict === 'warn') {
+    lines.push(`::warning title=Quorum Review Warning::${summary}. ${data.topFinding}`);
+  } else {
+    lines.push(`::notice title=Quorum Review Passed::${summary}. ${data.topFinding}`);
+  }
+
+  if (data.dissent) {
+    const shortDissent =
+      data.dissent.length > 200 ? data.dissent.slice(0, 197) + '...' : data.dissent;
+    lines.push(`::warning title=Quorum Dissent::${shortDissent}`);
+  }
+
+  return lines.join('\n');
+}
+
+// --- Main render function ---
+
+export function renderCard(
+  data: SummaryCardData,
+  format: CardFormat,
+  detailed: boolean = false,
+): string {
+  switch (format) {
+    case 'json':
+      return renderJson(data);
+    case 'html':
+      return renderHtml(data);
+    case 'markdown':
+    default:
+      return detailed ? renderDetailedMarkdown(data) : renderCompactMarkdown(data);
+  }
+}
+
+// --- Convenience: from deliberation result directly ---
+
+export function generateSummaryCard(
+  input: SummaryCardInput,
+  format: CardFormat = 'markdown',
+  detailed: boolean = false,
+): string {
+  const data = buildCardData(input);
+  return renderCard(data, format, detailed);
+}
+
+export function generateAnnotations(input: SummaryCardInput): string {
+  const data = buildCardData(input);
+  return renderGitHubAnnotations(data);
+}


### PR DESCRIPTION
## Summary

Adds embedded summary card generation for GitHub PR checks, Slack, and other surfaces.

### New: `src/summary-card.ts`
- **Compact card** (≤500 chars) with verdict emoji, confidence/consensus scores, top finding, dissent, provider breakdown, and drill-down link
- **Detailed card** (no char limit) with full tables and all context
- **Three formats:** markdown, JSON, HTML
- **GitHub Actions annotations:** `::notice` / `::warning` / `::error` compatible output

### CLI Integration
- `quorum ci --card` — outputs compact summary card to stdout
- `quorum ci --card-format markdown|json|html` — choose format
- `quorum ci --card-detailed` — detailed card (no char limit)
- `quorum ci --annotations` — GitHub Actions annotation format
- `quorum review --card` — delegates to ci with card output

### Tests
29 new tests covering verdict computation, card data building, all render formats, budget enforcement, and edge cases.

Closes #28