### PR TITLE
feat: reliability and policy controls (#31)

### DIFF
--- a/src/calibration.test.ts
+++ b/src/calibration.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeCalibrationStats,
+  formatCalibrationStats,
+  type CalibrationStore,
+  type CalibrationEntry,
+} from './calibration.js';
+
+function makeEntry(
+  overrides: Partial<CalibrationEntry> & {
+    prediction?: Partial<CalibrationEntry['prediction']>;
+  } = {},
+): CalibrationEntry {
+  return {
+    id: `cal-${Math.random().toString(36).slice(2)}`,
+    timestamp: new Date().toISOString(),
+    sessionId: `session-${Math.random().toString(36).slice(2)}`,
+    prediction: {
+      tier: 'medium',
+      consensus: 0.7,
+      confidence: 0.6,
+      dissentSeverity: 0.3,
+      providerAgreement: 0.7,
+      ...overrides.prediction,
+    },
+    outcome: overrides.outcome,
+  };
+}
+
+describe('computeCalibrationStats', () => {
+  it('handles empty store', () => {
+    const store: CalibrationStore = { version: 1, entries: [] };
+    const stats = computeCalibrationStats(store);
+    expect(stats.totalPredictions).toBe(0);
+    expect(stats.withOutcomes).toBe(0);
+    expect(stats.tierAccuracy).toBe(0);
+    expect(stats.acceptanceRate).toBe(0);
+  });
+
+  it('counts predictions without outcomes', () => {
+    const store: CalibrationStore = {
+      version: 1,
+      entries: [makeEntry(), makeEntry(), makeEntry()],
+    };
+    const stats = computeCalibrationStats(store);
+    expect(stats.totalPredictions).toBe(3);
+    expect(stats.withOutcomes).toBe(0);
+  });
+
+  it('computes tier accuracy correctly', () => {
+    const store: CalibrationStore = {
+      version: 1,
+      entries: [
+        makeEntry({
+          outcome: { accepted: true, tierAccurate: true, recordedAt: new Date().toISOString() },
+        }),
+        makeEntry({
+          outcome: { accepted: true, tierAccurate: false, recordedAt: new Date().toISOString() },
+        }),
+        makeEntry({
+          outcome: { accepted: false, tierAccurate: true, recordedAt: new Date().toISOString() },
+        }),
+      ],
+    };
+    const stats = computeCalibrationStats(store);
+    expect(stats.withOutcomes).toBe(3);
+    expect(stats.tierAccuracy).toBeCloseTo(2 / 3);
+    expect(stats.acceptanceRate).toBeCloseTo(2 / 3);
+  });
+
+  it('tracks by-tier stats', () => {
+    const store: CalibrationStore = {
+      version: 1,
+      entries: [
+        makeEntry({
+          prediction: {
+            tier: 'low',
+            consensus: 0.9,
+            confidence: 0.9,
+            dissentSeverity: 0.1,
+            providerAgreement: 0.9,
+          },
+          outcome: { accepted: true, tierAccurate: true, recordedAt: new Date().toISOString() },
+        }),
+        makeEntry({
+          prediction: {
+            tier: 'critical',
+            consensus: 0.1,
+            confidence: 0.1,
+            dissentSeverity: 0.9,
+            providerAgreement: 0.1,
+          },
+          outcome: { accepted: false, tierAccurate: true, recordedAt: new Date().toISOString() },
+        }),
+      ],
+    };
+    const stats = computeCalibrationStats(store);
+    expect(stats.byTier.low.count).toBe(1);
+    expect(stats.byTier.low.accepted).toBe(1);
+    expect(stats.byTier.critical.count).toBe(1);
+    expect(stats.byTier.critical.accepted).toBe(0);
+  });
+
+  it('computes confidence calibration buckets', () => {
+    const store: CalibrationStore = {
+      version: 1,
+      entries: [
+        makeEntry({
+          prediction: {
+            tier: 'low',
+            consensus: 0.9,
+            confidence: 0.9,
+            dissentSeverity: 0.1,
+            providerAgreement: 0.9,
+          },
+        }),
+        makeEntry({
+          prediction: {
+            tier: 'medium',
+            consensus: 0.5,
+            confidence: 0.5,
+            dissentSeverity: 0.3,
+            providerAgreement: 0.7,
+          },
+        }),
+      ],
+    };
+    const stats = computeCalibrationStats(store);
+    const highBucket = stats.confidenceCalibration.find((b) => b.bucket === '80-100%');
+    expect(highBucket?.predictions).toBe(1);
+    const midBucket = stats.confidenceCalibration.find((b) => b.bucket === '40-60%');
+    expect(midBucket?.predictions).toBe(1);
+  });
+});
+
+describe('formatCalibrationStats', () => {
+  it('formats stats as readable string', () => {
+    const store: CalibrationStore = {
+      version: 1,
+      entries: [
+        makeEntry({
+          prediction: {
+            tier: 'low',
+            consensus: 0.9,
+            confidence: 0.9,
+            dissentSeverity: 0.1,
+            providerAgreement: 0.9,
+          },
+          outcome: { accepted: true, tierAccurate: true, recordedAt: new Date().toISOString() },
+        }),
+      ],
+    };
+    const stats = computeCalibrationStats(store);
+    const formatted = formatCalibrationStats(stats);
+    expect(formatted).toContain('📊 Calibration Stats');
+    expect(formatted).toContain('Total predictions: 1');
+    expect(formatted).toContain('🟢');
+  });
+});

--- a/src/calibration.ts
+++ b/src/calibration.ts
@@ -1,0 +1,261 @@
+/**
+ * Calibration Tracking — Feature #31
+ *
+ * Logs predictions (risk tier + confidence) vs. actual outcomes over time.
+ * Stored in ~/.quorum/calibration.json for accuracy analysis.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { RiskTier } from './risk-tier.js';
+
+// --- Types ---
+
+export interface CalibrationEntry {
+  id: string;
+  timestamp: string;
+  sessionId: string;
+  prediction: {
+    tier: RiskTier;
+    consensus: number;
+    confidence: number;
+    dissentSeverity: number;
+    providerAgreement: number;
+  };
+  outcome?: {
+    /** Whether the human accepted the result as-is */
+    accepted: boolean;
+    /** Optional feedback: was the risk tier accurate? */
+    tierAccurate: boolean;
+    /** Timestamp when outcome was recorded */
+    recordedAt: string;
+    /** Free-form note */
+    note?: string;
+  };
+}
+
+export interface CalibrationStore {
+  version: number;
+  entries: CalibrationEntry[];
+}
+
+export interface CalibrationStats {
+  totalPredictions: number;
+  withOutcomes: number;
+  tierAccuracy: number;
+  acceptanceRate: number;
+  byTier: Record<
+    RiskTier,
+    {
+      count: number;
+      withOutcomes: number;
+      accurate: number;
+      accepted: number;
+    }
+  >;
+  confidenceCalibration: Array<{
+    bucket: string;
+    predictions: number;
+    accepted: number;
+    rate: number;
+  }>;
+}
+
+// --- Storage ---
+
+function calibrationPath(): string {
+  return join(homedir(), '.quorum', 'calibration.json');
+}
+
+export async function loadCalibrationStore(): Promise<CalibrationStore> {
+  const path = calibrationPath();
+  if (!existsSync(path)) {
+    return { version: 1, entries: [] };
+  }
+  try {
+    const raw = await readFile(path, 'utf-8');
+    return JSON.parse(raw) as CalibrationStore;
+  } catch {
+    return { version: 1, entries: [] };
+  }
+}
+
+export async function saveCalibrationStore(store: CalibrationStore): Promise<void> {
+  const path = calibrationPath();
+  const dir = join(homedir(), '.quorum');
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+  await writeFile(path, JSON.stringify(store, null, 2), 'utf-8');
+}
+
+// --- Operations ---
+
+/**
+ * Record a new prediction from a deliberation.
+ */
+export async function recordPrediction(params: {
+  sessionId: string;
+  tier: RiskTier;
+  consensus: number;
+  confidence: number;
+  dissentSeverity: number;
+  providerAgreement: number;
+}): Promise<CalibrationEntry> {
+  const store = await loadCalibrationStore();
+
+  const entry: CalibrationEntry = {
+    id: `cal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: new Date().toISOString(),
+    sessionId: params.sessionId,
+    prediction: {
+      tier: params.tier,
+      consensus: params.consensus,
+      confidence: params.confidence,
+      dissentSeverity: params.dissentSeverity,
+      providerAgreement: params.providerAgreement,
+    },
+  };
+
+  store.entries.push(entry);
+  await saveCalibrationStore(store);
+  return entry;
+}
+
+/**
+ * Record an outcome for a previous prediction.
+ */
+export async function recordOutcome(params: {
+  sessionId: string;
+  accepted: boolean;
+  tierAccurate: boolean;
+  note?: string;
+}): Promise<boolean> {
+  const store = await loadCalibrationStore();
+
+  const entry = store.entries.find((e) => e.sessionId === params.sessionId);
+  if (!entry) return false;
+
+  entry.outcome = {
+    accepted: params.accepted,
+    tierAccurate: params.tierAccurate,
+    recordedAt: new Date().toISOString(),
+    note: params.note,
+  };
+
+  await saveCalibrationStore(store);
+  return true;
+}
+
+/**
+ * Compute calibration statistics.
+ */
+export function computeCalibrationStats(store: CalibrationStore): CalibrationStats {
+  const tiers: RiskTier[] = ['low', 'medium', 'high', 'critical'];
+
+  const byTier = Object.fromEntries(
+    tiers.map((t) => [t, { count: 0, withOutcomes: 0, accurate: 0, accepted: 0 }]),
+  ) as CalibrationStats['byTier'];
+
+  let withOutcomes = 0;
+  let tierAccurate = 0;
+  let accepted = 0;
+
+  for (const entry of store.entries) {
+    const tier = entry.prediction.tier;
+    byTier[tier].count++;
+
+    if (entry.outcome) {
+      withOutcomes++;
+      byTier[tier].withOutcomes++;
+
+      if (entry.outcome.tierAccurate) {
+        tierAccurate++;
+        byTier[tier].accurate++;
+      }
+      if (entry.outcome.accepted) {
+        accepted++;
+        byTier[tier].accepted++;
+      }
+    }
+  }
+
+  // Confidence calibration buckets (0-20%, 20-40%, 40-60%, 60-80%, 80-100%)
+  const buckets = [
+    { label: '0-20%', min: 0, max: 0.2 },
+    { label: '20-40%', min: 0.2, max: 0.4 },
+    { label: '40-60%', min: 0.4, max: 0.6 },
+    { label: '60-80%', min: 0.6, max: 0.8 },
+    { label: '80-100%', min: 0.8, max: 1.01 },
+  ];
+
+  const confidenceCalibration = buckets.map((bucket) => {
+    const inBucket = store.entries.filter(
+      (e) => e.prediction.confidence >= bucket.min && e.prediction.confidence < bucket.max,
+    );
+    const acceptedInBucket = inBucket.filter((e) => e.outcome?.accepted).length;
+    return {
+      bucket: bucket.label,
+      predictions: inBucket.length,
+      accepted: acceptedInBucket,
+      rate: inBucket.length > 0 ? acceptedInBucket / inBucket.length : 0,
+    };
+  });
+
+  return {
+    totalPredictions: store.entries.length,
+    withOutcomes,
+    tierAccuracy: withOutcomes > 0 ? tierAccurate / withOutcomes : 0,
+    acceptanceRate: withOutcomes > 0 ? accepted / withOutcomes : 0,
+    byTier,
+    confidenceCalibration,
+  };
+}
+
+/**
+ * Format calibration stats for display.
+ */
+export function formatCalibrationStats(stats: CalibrationStats): string {
+  const lines: string[] = [
+    '📊 Calibration Stats',
+    '',
+    `  Total predictions: ${stats.totalPredictions}`,
+    `  With outcomes:     ${stats.withOutcomes}`,
+    `  Tier accuracy:     ${(stats.tierAccuracy * 100).toFixed(1)}%`,
+    `  Acceptance rate:   ${(stats.acceptanceRate * 100).toFixed(1)}%`,
+    '',
+    '  By Tier:',
+  ];
+
+  const tiers: RiskTier[] = ['low', 'medium', 'high', 'critical'];
+  const icons: Record<RiskTier, string> = {
+    low: '🟢',
+    medium: '🟡',
+    high: '🟠',
+    critical: '🔴',
+  };
+
+  for (const tier of tiers) {
+    const t = stats.byTier[tier];
+    if (t.count === 0) continue;
+    const accuracy = t.withOutcomes > 0 ? ((t.accurate / t.withOutcomes) * 100).toFixed(0) : 'N/A';
+    lines.push(
+      `    ${icons[tier]} ${tier.padEnd(8)} ${t.count} predictions, ${accuracy}% accurate`,
+    );
+  }
+
+  if (stats.confidenceCalibration.some((b) => b.predictions > 0)) {
+    lines.push('', '  Confidence Calibration:');
+    for (const bucket of stats.confidenceCalibration) {
+      if (bucket.predictions === 0) continue;
+      const bar = '█'.repeat(Math.round(bucket.rate * 10));
+      lines.push(
+        `    ${bucket.bucket.padEnd(8)} ${bar} ${(bucket.rate * 100).toFixed(0)}% (${bucket.predictions} predictions)`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/policy-controls.test.ts
+++ b/src/policy-controls.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { validatePolicyConfig, formatPolicyConfig, defaultPolicyPath } from './policy-controls.js';
+import { DEFAULT_POLICY } from './risk-tier.js';
+
+describe('validatePolicyConfig', () => {
+  it('accepts valid default policy', () => {
+    const errors = validatePolicyConfig(DEFAULT_POLICY);
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects non-object', () => {
+    expect(validatePolicyConfig(null)).toEqual(['Policy must be an object']);
+    expect(validatePolicyConfig('string')).toEqual(['Policy must be an object']);
+  });
+
+  it('rejects missing version', () => {
+    const errors = validatePolicyConfig({ tiers: {} });
+    expect(errors.some((e) => e.includes('version'))).toBe(true);
+  });
+
+  it('rejects invalid default action', () => {
+    const errors = validatePolicyConfig({
+      version: 1,
+      defaultAction: 'invalid',
+      tiers: DEFAULT_POLICY.tiers,
+    });
+    expect(errors.some((e) => e.includes('defaultAction'))).toBe(true);
+  });
+
+  it('rejects missing tiers', () => {
+    const errors = validatePolicyConfig({ version: 1 });
+    expect(errors.some((e) => e.includes('tiers'))).toBe(true);
+  });
+
+  it('rejects missing tier entries', () => {
+    const errors = validatePolicyConfig({
+      version: 1,
+      tiers: { low: DEFAULT_POLICY.tiers.low },
+    });
+    expect(errors.some((e) => e.includes('medium'))).toBe(true);
+  });
+
+  it('rejects invalid threshold values', () => {
+    const badPolicy = {
+      version: 1,
+      tiers: {
+        low: {
+          thresholds: {
+            consensusMin: 2, // invalid: > 1
+            confidenceMin: 0.8,
+            dissentMax: 0.2,
+            providerAgreementMin: 0.8,
+          },
+          action: 'auto-approve',
+        },
+        medium: DEFAULT_POLICY.tiers.medium,
+        high: DEFAULT_POLICY.tiers.high,
+        critical: DEFAULT_POLICY.tiers.critical,
+      },
+    };
+    const errors = validatePolicyConfig(badPolicy);
+    expect(errors.some((e) => e.includes('consensusMin'))).toBe(true);
+  });
+
+  it('rejects invalid tier action', () => {
+    const badPolicy = {
+      version: 1,
+      tiers: {
+        low: {
+          thresholds: DEFAULT_POLICY.tiers.low.thresholds,
+          action: 'invalid-action',
+        },
+        medium: DEFAULT_POLICY.tiers.medium,
+        high: DEFAULT_POLICY.tiers.high,
+        critical: DEFAULT_POLICY.tiers.critical,
+      },
+    };
+    const errors = validatePolicyConfig(badPolicy);
+    expect(errors.some((e) => e.includes('invalid-action'))).toBe(true);
+  });
+});
+
+describe('formatPolicyConfig', () => {
+  it('formats default policy readably', () => {
+    const formatted = formatPolicyConfig(DEFAULT_POLICY);
+    expect(formatted).toContain('📋 Policy v1');
+    expect(formatted).toContain('🟢');
+    expect(formatted).toContain('LOW');
+    expect(formatted).toContain('🔴');
+    expect(formatted).toContain('CRITICAL');
+    expect(formatted).toContain('auto-approve');
+    expect(formatted).toContain('block');
+  });
+});
+
+describe('defaultPolicyPath', () => {
+  it('returns a path ending with .quorum/policy.yml', () => {
+    const path = defaultPolicyPath();
+    expect(path).toContain('.quorum');
+    expect(path).toContain('policy.yml');
+  });
+});

--- a/src/policy-controls.ts
+++ b/src/policy-controls.ts
@@ -1,0 +1,196 @@
+/**
+ * Policy Controls — Feature #31
+ *
+ * High-level policy configuration using `.quorum/policy.yml`.
+ * Defines risk tier thresholds and actions, with init/show/validate commands.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { PolicyConfig, RiskTier, TierAction } from './risk-tier.js';
+import { DEFAULT_POLICY } from './risk-tier.js';
+
+// --- Types ---
+
+export interface PolicyFileError {
+  path: string;
+  message: string;
+}
+
+// --- Default YAML content ---
+
+const DEFAULT_POLICY_YAML = `# Quorum Policy Configuration
+# See: https://github.com/Solvely-Colin/Quorum#policy-controls
+version: 1
+defaultAction: warn
+
+tiers:
+  low:
+    thresholds:
+      consensusMin: 0.8
+      confidenceMin: 0.8
+      dissentMax: 0.2
+      providerAgreementMin: 0.8
+    action: auto-approve
+    description: "Strong consensus — advisory only"
+
+  medium:
+    thresholds:
+      consensusMin: 0.6
+      confidenceMin: 0.6
+      dissentMax: 0.4
+      providerAgreementMin: 0.6
+    action: warn
+    description: "Moderate agreement — surface dissent"
+
+  high:
+    thresholds:
+      consensusMin: 0.4
+      confidenceMin: 0.4
+      dissentMax: 0.6
+      providerAgreementMin: 0.4
+    action: checkpoint
+    description: "Low agreement — human review recommended"
+
+  critical:
+    thresholds:
+      consensusMin: 0.0
+      confidenceMin: 0.0
+      dissentMax: 1.0
+      providerAgreementMin: 0.0
+    action: block
+    description: "Critical disagreement — escalation required"
+`;
+
+// --- File Operations ---
+
+/**
+ * Get the default policy file path (.quorum/policy.yml in cwd).
+ */
+export function defaultPolicyPath(): string {
+  return join(process.cwd(), '.quorum', 'policy.yml');
+}
+
+/**
+ * Initialize a default policy file.
+ */
+export async function initPolicyFile(path?: string): Promise<string> {
+  const filePath = path ?? defaultPolicyPath();
+  const dir = join(filePath, '..');
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+  await writeFile(filePath, DEFAULT_POLICY_YAML, 'utf-8');
+  return filePath;
+}
+
+/**
+ * Load a policy config from a YAML file.
+ */
+export async function loadPolicyFile(path?: string): Promise<PolicyConfig> {
+  const filePath = path ?? defaultPolicyPath();
+  if (!existsSync(filePath)) {
+    return DEFAULT_POLICY;
+  }
+  const raw = await readFile(filePath, 'utf-8');
+  const parsed = parseYaml(raw) as PolicyConfig;
+  return parsed;
+}
+
+/**
+ * Validate a policy config object. Returns errors (empty = valid).
+ */
+export function validatePolicyConfig(config: unknown): string[] {
+  const errors: string[] = [];
+
+  if (!config || typeof config !== 'object') {
+    return ['Policy must be an object'];
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (typeof c.version !== 'number') {
+    errors.push('Missing or invalid "version" (must be a number)');
+  }
+
+  const validActions: TierAction[] = ['auto-approve', 'warn', 'checkpoint', 'block'];
+
+  if (c.defaultAction && !validActions.includes(c.defaultAction as TierAction)) {
+    errors.push(
+      `Invalid "defaultAction": "${c.defaultAction}". Must be one of: ${validActions.join(', ')}`,
+    );
+  }
+
+  if (!c.tiers || typeof c.tiers !== 'object') {
+    errors.push('Missing or invalid "tiers" object');
+    return errors;
+  }
+
+  const validTiers: RiskTier[] = ['low', 'medium', 'high', 'critical'];
+  const tiers = c.tiers as Record<string, unknown>;
+
+  for (const tierName of validTiers) {
+    if (!tiers[tierName]) {
+      errors.push(`Missing tier: "${tierName}"`);
+      continue;
+    }
+
+    const tier = tiers[tierName] as Record<string, unknown>;
+
+    if (!tier.thresholds || typeof tier.thresholds !== 'object') {
+      errors.push(`Tier "${tierName}": missing or invalid "thresholds"`);
+      continue;
+    }
+
+    const t = tier.thresholds as Record<string, unknown>;
+    for (const key of ['consensusMin', 'confidenceMin', 'dissentMax', 'providerAgreementMin']) {
+      if (typeof t[key] !== 'number' || t[key] < 0 || t[key] > 1) {
+        errors.push(`Tier "${tierName}": thresholds.${key} must be a number between 0 and 1`);
+      }
+    }
+
+    if (!validActions.includes(tier.action as TierAction)) {
+      errors.push(
+        `Tier "${tierName}": invalid action "${tier.action}". Must be one of: ${validActions.join(', ')}`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Format a policy config for display.
+ */
+export function formatPolicyConfig(config: PolicyConfig): string {
+  const icons: Record<RiskTier, string> = {
+    low: '🟢',
+    medium: '🟡',
+    high: '🟠',
+    critical: '🔴',
+  };
+
+  const lines: string[] = [
+    `📋 Policy v${config.version}`,
+    `  Default action: ${config.defaultAction}`,
+    '',
+  ];
+
+  const tierOrder: RiskTier[] = ['low', 'medium', 'high', 'critical'];
+  for (const tierName of tierOrder) {
+    const tier = config.tiers[tierName];
+    if (!tier) continue;
+    const t = tier.thresholds;
+    lines.push(`  ${icons[tierName]} ${tierName.toUpperCase()}`);
+    lines.push(`    Action: ${tier.action}`);
+    lines.push(`    ${tier.description}`);
+    lines.push(
+      `    Consensus ≥ ${t.consensusMin} | Confidence ≥ ${t.confidenceMin} | Dissent ≤ ${t.dissentMax} | Agreement ≥ ${t.providerAgreementMin}`,
+    );
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/risk-tier.test.ts
+++ b/src/risk-tier.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyRisk,
+  computeProviderAgreement,
+  computeDissentSeverity,
+  formatRiskAssessment,
+  type DeliberationInput,
+} from './risk-tier.js';
+
+describe('computeProviderAgreement', () => {
+  it('returns 1.0 for single provider', () => {
+    expect(computeProviderAgreement([{ provider: 'a', score: 10 }])).toBe(1.0);
+  });
+
+  it('returns 1.0 when all scores are equal', () => {
+    const rankings = [
+      { provider: 'a', score: 10 },
+      { provider: 'b', score: 10 },
+      { provider: 'c', score: 10 },
+    ];
+    expect(computeProviderAgreement(rankings)).toBe(1.0);
+  });
+
+  it('returns lower value when scores diverge', () => {
+    const rankings = [
+      { provider: 'a', score: 10 },
+      { provider: 'b', score: 5 },
+      { provider: 'c', score: 2 },
+    ];
+    const agreement = computeProviderAgreement(rankings);
+    expect(agreement).toBeLessThan(1.0);
+    expect(agreement).toBeGreaterThan(0);
+  });
+
+  it('returns 0 when top score is 0', () => {
+    const rankings = [
+      { provider: 'a', score: 0 },
+      { provider: 'b', score: 0 },
+    ];
+    expect(computeProviderAgreement(rankings)).toBe(0);
+  });
+});
+
+describe('computeDissentSeverity', () => {
+  it('returns 0 for non-controversial with no minority report', () => {
+    expect(computeDissentSeverity(false)).toBe(0);
+  });
+
+  it('returns 0.4 for controversial with no minority report', () => {
+    expect(computeDissentSeverity(true)).toBe(0.4);
+  });
+
+  it('returns 0 for "None" minority report', () => {
+    expect(computeDissentSeverity(false, 'None')).toBe(0);
+  });
+
+  it('increases with longer minority reports', () => {
+    const short = computeDissentSeverity(false, 'Some minor disagreement.');
+    const long = computeDissentSeverity(
+      false,
+      'There was significant disagreement among the providers about the fundamental approach to this problem. Multiple providers raised concerns about accuracy, methodology, and the overall framing of the question. The dissent centered around three key areas that require careful consideration.',
+    );
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it('caps at 1.0', () => {
+    const longText = 'word '.repeat(500);
+    expect(computeDissentSeverity(true, longText)).toBeLessThanOrEqual(1.0);
+  });
+});
+
+describe('classifyRisk', () => {
+  it('classifies high consensus as low risk', () => {
+    const input: DeliberationInput = {
+      consensusScore: 0.9,
+      confidenceScore: 0.85,
+      controversial: false,
+      rankings: [
+        { provider: 'a', score: 10 },
+        { provider: 'b', score: 9 },
+        { provider: 'c', score: 9 },
+      ],
+    };
+    const result = classifyRisk(input);
+    expect(result.tier).toBe('low');
+    expect(result.action).toBe('auto-approve');
+  });
+
+  it('classifies moderate scores as medium risk', () => {
+    const input: DeliberationInput = {
+      consensusScore: 0.65,
+      confidenceScore: 0.7,
+      controversial: false,
+      rankings: [
+        { provider: 'a', score: 10 },
+        { provider: 'b', score: 8 },
+        { provider: 'c', score: 7 },
+      ],
+    };
+    const result = classifyRisk(input);
+    expect(result.tier).toBe('medium');
+    expect(result.action).toBe('warn');
+  });
+
+  it('classifies low consensus as high risk', () => {
+    const input: DeliberationInput = {
+      consensusScore: 0.45,
+      confidenceScore: 0.45,
+      controversial: false,
+      rankings: [
+        { provider: 'a', score: 10 },
+        { provider: 'b', score: 8 },
+        { provider: 'c', score: 7 },
+      ],
+    };
+    const result = classifyRisk(input);
+    expect(result.tier).toBe('high');
+    expect(result.action).toBe('checkpoint');
+  });
+
+  it('classifies very low scores as critical', () => {
+    const input: DeliberationInput = {
+      consensusScore: 0.2,
+      confidenceScore: 0.15,
+      controversial: true,
+      rankings: [
+        { provider: 'a', score: 10 },
+        { provider: 'b', score: 2 },
+        { provider: 'c', score: 1 },
+      ],
+      minorityReport:
+        'Major disagreement across all providers. Fundamental concerns raised about accuracy and methodology.',
+    };
+    const result = classifyRisk(input);
+    expect(result.tier).toBe('critical');
+    expect(result.action).toBe('block');
+  });
+
+  it('uses default policy when none provided', () => {
+    const input: DeliberationInput = {
+      consensusScore: 0.9,
+      confidenceScore: 0.9,
+      controversial: false,
+      rankings: [
+        { provider: 'a', score: 10 },
+        { provider: 'b', score: 10 },
+      ],
+    };
+    const result = classifyRisk(input);
+    expect(result.tier).toBe('low');
+  });
+});
+
+describe('formatRiskAssessment', () => {
+  it('formats low risk with green icon', () => {
+    const assessment = classifyRisk({
+      consensusScore: 0.9,
+      confidenceScore: 0.9,
+      controversial: false,
+      rankings: [
+        { provider: 'a', score: 10 },
+        { provider: 'b', score: 10 },
+      ],
+    });
+    const formatted = formatRiskAssessment(assessment);
+    expect(formatted).toContain('🟢');
+    expect(formatted).toContain('LOW');
+    expect(formatted).toContain('auto-approve');
+  });
+
+  it('formats critical risk with red icon', () => {
+    const assessment = classifyRisk({
+      consensusScore: 0.1,
+      confidenceScore: 0.1,
+      controversial: true,
+      rankings: [
+        { provider: 'a', score: 10 },
+        { provider: 'b', score: 1 },
+      ],
+      minorityReport: 'Major disagreement on all points.',
+    });
+    const formatted = formatRiskAssessment(assessment);
+    expect(formatted).toContain('🔴');
+    expect(formatted).toContain('CRITICAL');
+  });
+});

--- a/src/risk-tier.ts
+++ b/src/risk-tier.ts
@@ -1,0 +1,242 @@
+/**
+ * Risk Tier Classification — Feature #31
+ *
+ * Classifies deliberation results into risk tiers based on
+ * consensus score, confidence score, dissent severity, and provider agreement.
+ * Each tier maps to an action: auto-approve, warn, checkpoint, or block.
+ */
+
+// --- Types ---
+
+export type RiskTier = 'low' | 'medium' | 'high' | 'critical';
+
+export type TierAction = 'auto-approve' | 'warn' | 'checkpoint' | 'block';
+
+export interface RiskThresholds {
+  /** Consensus score below this is risky (0-1) */
+  consensusMin: number;
+  /** Confidence score below this is risky (0-1) */
+  confidenceMin: number;
+  /** Dissent severity above this is risky (0-1) */
+  dissentMax: number;
+  /** Minimum provider agreement ratio (0-1) */
+  providerAgreementMin: number;
+}
+
+export interface TierConfig {
+  thresholds: RiskThresholds;
+  action: TierAction;
+  description: string;
+}
+
+export interface PolicyConfig {
+  version: number;
+  defaultAction: TierAction;
+  tiers: Record<RiskTier, TierConfig>;
+}
+
+export interface RiskAssessment {
+  tier: RiskTier;
+  action: TierAction;
+  scores: {
+    consensus: number;
+    confidence: number;
+    dissentSeverity: number;
+    providerAgreement: number;
+  };
+  reasons: string[];
+  description: string;
+}
+
+export interface DeliberationInput {
+  consensusScore: number;
+  confidenceScore: number;
+  controversial: boolean;
+  rankings: Array<{ provider: string; score: number }>;
+  minorityReport?: string;
+}
+
+// --- Default Policy ---
+
+export const DEFAULT_POLICY: PolicyConfig = {
+  version: 1,
+  defaultAction: 'warn',
+  tiers: {
+    low: {
+      thresholds: {
+        consensusMin: 0.8,
+        confidenceMin: 0.8,
+        dissentMax: 0.2,
+        providerAgreementMin: 0.8,
+      },
+      action: 'auto-approve',
+      description: 'Strong consensus — advisory only',
+    },
+    medium: {
+      thresholds: {
+        consensusMin: 0.6,
+        confidenceMin: 0.6,
+        dissentMax: 0.4,
+        providerAgreementMin: 0.6,
+      },
+      action: 'warn',
+      description: 'Moderate agreement — surface dissent',
+    },
+    high: {
+      thresholds: {
+        consensusMin: 0.4,
+        confidenceMin: 0.4,
+        dissentMax: 0.6,
+        providerAgreementMin: 0.4,
+      },
+      action: 'checkpoint',
+      description: 'Low agreement — human review recommended',
+    },
+    critical: {
+      thresholds: {
+        consensusMin: 0.0,
+        confidenceMin: 0.0,
+        dissentMax: 1.0,
+        providerAgreementMin: 0.0,
+      },
+      action: 'block',
+      description: 'Critical disagreement — escalation required',
+    },
+  },
+};
+
+// --- Scoring ---
+
+/**
+ * Compute provider agreement ratio from rankings.
+ * Measures how close the top scores are relative to the winner.
+ */
+export function computeProviderAgreement(
+  rankings: Array<{ provider: string; score: number }>,
+): number {
+  if (rankings.length < 2) return 1.0;
+  const sorted = [...rankings].sort((a, b) => b.score - a.score);
+  const topScore = sorted[0].score;
+  if (topScore === 0) return 0;
+
+  // Ratio of scores that are within 20% of top score
+  const agreeing = sorted.filter((r) => r.score >= topScore * 0.8).length;
+  return agreeing / sorted.length;
+}
+
+/**
+ * Compute dissent severity from minority report and controversy flag.
+ * Returns 0-1 scale.
+ */
+export function computeDissentSeverity(controversial: boolean, minorityReport?: string): number {
+  let severity = 0;
+
+  if (controversial) severity += 0.4;
+
+  if (minorityReport && minorityReport.trim() && minorityReport.toLowerCase() !== 'none') {
+    // Longer minority reports indicate more dissent
+    const wordCount = minorityReport.split(/\s+/).length;
+    severity += Math.min(0.6, wordCount / 200);
+  }
+
+  return Math.min(1.0, severity);
+}
+
+/**
+ * Classify a deliberation result into a risk tier.
+ */
+export function classifyRisk(
+  input: DeliberationInput,
+  policy: PolicyConfig = DEFAULT_POLICY,
+): RiskAssessment {
+  const providerAgreement = computeProviderAgreement(input.rankings);
+  const dissentSeverity = computeDissentSeverity(input.controversial, input.minorityReport);
+
+  const scores = {
+    consensus: input.consensusScore,
+    confidence: input.confidenceScore,
+    dissentSeverity,
+    providerAgreement,
+  };
+
+  const reasons: string[] = [];
+
+  // Check tiers from best to worst
+  const tierOrder: RiskTier[] = ['low', 'medium', 'high', 'critical'];
+
+  for (const tierName of tierOrder) {
+    const tier = policy.tiers[tierName];
+    const t = tier.thresholds;
+
+    const meetsConsensus = scores.consensus >= t.consensusMin;
+    const meetsConfidence = scores.confidence >= t.confidenceMin;
+    const meetsDissent = scores.dissentSeverity <= t.dissentMax;
+    const meetsAgreement = scores.providerAgreement >= t.providerAgreementMin;
+
+    if (meetsConsensus && meetsConfidence && meetsDissent && meetsAgreement) {
+      if (!meetsConsensus) reasons.push(`Consensus ${scores.consensus} below ${t.consensusMin}`);
+      if (!meetsConfidence)
+        reasons.push(`Confidence ${scores.confidence} below ${t.confidenceMin}`);
+      if (!meetsDissent) reasons.push(`Dissent ${scores.dissentSeverity} above ${t.dissentMax}`);
+      if (!meetsAgreement)
+        reasons.push(
+          `Provider agreement ${scores.providerAgreement} below ${t.providerAgreementMin}`,
+        );
+
+      return {
+        tier: tierName,
+        action: tier.action,
+        scores,
+        reasons,
+        description: tier.description,
+      };
+    }
+
+    // Collect reasons why this tier wasn't met
+    if (!meetsConsensus)
+      reasons.push(`Consensus ${scores.consensus.toFixed(2)} below ${t.consensusMin}`);
+    if (!meetsConfidence)
+      reasons.push(`Confidence ${scores.confidence.toFixed(2)} below ${t.confidenceMin}`);
+    if (!meetsDissent)
+      reasons.push(`Dissent severity ${scores.dissentSeverity.toFixed(2)} above ${t.dissentMax}`);
+    if (!meetsAgreement)
+      reasons.push(
+        `Provider agreement ${scores.providerAgreement.toFixed(2)} below ${t.providerAgreementMin}`,
+      );
+  }
+
+  // Fallback to critical
+  const criticalTier = policy.tiers.critical;
+  return {
+    tier: 'critical',
+    action: criticalTier.action,
+    scores,
+    reasons,
+    description: criticalTier.description,
+  };
+}
+
+/**
+ * Format a risk assessment for display.
+ */
+export function formatRiskAssessment(assessment: RiskAssessment): string {
+  const icons: Record<RiskTier, string> = {
+    low: '🟢',
+    medium: '🟡',
+    high: '🟠',
+    critical: '🔴',
+  };
+
+  const lines = [
+    `${icons[assessment.tier]} Risk: ${assessment.tier.toUpperCase()} — ${assessment.description}`,
+    `  Action: ${assessment.action}`,
+    `  Consensus: ${(assessment.scores.consensus * 100).toFixed(0)}% | Confidence: ${(assessment.scores.confidence * 100).toFixed(0)}%`,
+    `  Dissent: ${(assessment.scores.dissentSeverity * 100).toFixed(0)}% | Agreement: ${(assessment.scores.providerAgreement * 100).toFixed(0)}%`,
+  ];
+
+  if (assessment.reasons.length > 0) {
+    lines.push(`  Factors: ${assessment.reasons.join('; ')}`);
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Reliability and Policy Controls

Closes #31

### What's New

**Risk Tier Classification** (`src/risk-tier.ts`)
- Classifies deliberation results into 4 tiers: low, medium, high, critical
- Based on consensus score, confidence score, dissent severity, provider agreement
- Each tier maps to an action: auto-approve → warn → checkpoint → block

**Policy Configuration** (`src/policy-controls.ts`)
- YAML policy file at `.quorum/policy.yml`
- Schema for defining thresholds and actions per tier
- `quorum policy init` — creates default policy
- `quorum policy show` — displays current policy
- `quorum policy validate` — checks policy file

**Calibration Tracking** (`src/calibration.ts`)
- Logs prediction vs outcome over time at `~/.quorum/calibration.json`
- `quorum policy calibration` — shows accuracy stats
- Confidence calibration buckets, per-tier accuracy tracking

### Design Decisions
- **Default policy is warn-only** — no blocking, no breaking change
- Builds on existing `src/policy.ts` (rule-based guardrails) with higher-level tier classification
- All new modules have full test coverage

### Testing
```
npm run build && npm run lint && npm run format:check && npm test  # all pass
```